### PR TITLE
merged my version with carls' version

### DIFF
--- a/d5.4-deliverable-report.md
+++ b/d5.4-deliverable-report.md
@@ -228,20 +228,20 @@ The GND dataset includes links to DBpedia resource descriptions for many items, 
         <gndo:surname>Eisler</gndo:surname>
         ...
     </rdf:Description>
-
+ 
 <a name="PrimaryUseCaseGoals"></a> 
 ###Primary Use Case Goals
 
-Beyond providing a basis for large scale testing of the FP3 platform, the main goals from the user's perspective of this application of the platform are: 
+Beyond providing a basis for large scale testing of the FP3 platform, the main goals from the user's perspective of this application is to make GNDs identifiers more usable, and to enhance retrieval of publications in libraries. In detail this leads to the following sub-goals:
 
- - make GNDs more usable;
- - aggregate information about concepts identified by GNDs and enrich them with NER and dictionary matching;
- - add context around a GND concept, identifying related concepts;
- - for each document in the B3Kat catalogue,  use the GND IDs associated with the document to identify the main subject concepts of the document;
- - identify related documents connected to the same subject(s);
- -  create a tag cloud of co-occurring entities (places, persons, organizations ...) for each subject concept;
-   - e.g. Which places are mentioned in the title text of books about Hanns Eisler? How often do they occur?
-
+ - **Add context around a GND concept, and identifying related concepts**:
+  - Cluster GND identifiers based on their degree of coocurrence in library records. 
+  - Aggregate information about GND identifiers located in other datasets, i.e. textual descriptions, geo-information, images from DBpedia.
+ - **Enrich GND concepts by harnessing FP3 NER and dictionary matching capabilities**: 
+  - Find co-occurring entities (places, persons, organizations ...) for each subject concept. For instance it is analyzed which places are mentioned in the title text of books about Hanns Eisler? 
+  - Count-Of-Occurence-Analysis for mentioned entities, e.g. to create tag-clouds.
+ - **Enrich library records**: Recognize identifiers from catalogue records using the FP3 Dictionary Matcher, to identify text strings in the library records that are not yet linked to their corresponding GND identifier.
+ 
 <a name="BroadApproach"></a> 
 ### Broad Approach
 
@@ -287,7 +287,7 @@ For ease of deployment, the FP3 test platform will be composed from Docker image
 #### Storage Layer
 
 Although Marmotta has provided the RDF storage for much of the FP3 development, Virtuoso Open Source Edition (VOS) was chosen as the storage layer, to provide the quad store, LDP server and SPARQL endpoints. Evaluations tests have found Virtuoso to be scalable to 10 billion+ triples. Virtuoso Commercial Edition was not considered necessary for the calculated use case dataset sizes. VOS supports multiple cores, so a single server instance running on a single machine is suitable. The GND, B3Cat and DBpedia datasets will be loaded directly into the Virtuoso quad store.
- 
+
 <a name="Hardware"></a> 
 ### Hardware
 
@@ -363,21 +363,42 @@ This link will be used to fetch additional data, such as: `foaf:depiction`, `dbp
 <a name="UseCaseTaskDetails4"></a> 
 ####4: Get co-occurring concepts from B3Kat
 
-For a given B3Kat concept, we can get details of other B3Kat concepts which are co-occurring with it. For example, using the [B3Kat SPARQL endpoint](https://lod.b3kat.de/doc/de/sparql-endpoint/), we can find documents which reference concept Hanns Eisler in some way:
+For a given GND-ID we can query coocurring Subject Headings (GND-IDs, LcSH) and classification codes (RVK, DDC, Lccn,...) from records of the B3Kat at its [SPARQL endpoint](https://lod.b3kat.de/doc/de/sparql-endpoint/).
 
-    SELECT distinct ?s ?p WHERE { 
-     ?s ?p <http://d-nb.info/gnd/118529692>; # - Hanns Eisler
-    } ORDER BY ?s LIMIT 500
-returns:
+We can retrieve identifiers that appear in the same context/record with a GND-ID . All identifiers are marked as coocurrent and added to the GND-ID graph (cf. step 1): 
 
-| s | p |
-| :-- | :-- |
-| <http://lod.b3kat.de/title/BV000153283> | <http://id.loc.gov/vocabulary/relators/aut> |
-| <http://lod.b3kat.de/title/BV000153283> |<http://purl.org/dc/terms/creator> |
-| <http://lod.b3kat.de/title/BV000154417> | <http://purl.org/dc/terms/subject> |
-| <http://lod.b3kat.de/title/BV000192526> | <http://id.loc.gov/vocabulary/relators/aut> |
+    SELECT ?record ?cosubjectLabel ?cosubjectUri ?colccn ?coisbn ?cocreator
+    WHERE { 
+    ?record ?p <http://d-nb.info/gnd/118529692> . #- Hanns Eisler
+      OPTIONAL { ?s dc:subject ?cosubjectLabel }
+      OPTIONAL { ?s dct:subject ?cosubjectUri }
+      OPTIONAL { ?s bibo:lccn ?colccn }
+      OPTIONAL { ?s bibo:isbn ?coisbn }
+      OPTIONAL { ?s marcrel:aut ?cocreator }
+    }
+   
+Additionally, it is counted how often a concept co-occurs with the given GND-ID to compute a the distance measure. The distance `d` of a base concept `Cb` (i.e. Hanns Eisler) to a coocurrent concept `Cx` is computed as the percentage of the total record count having `Cb`.
 
-The `dct:subject`s of the returned B3Kat documents provide co-occurring GND concepts.
+    SELECT (count(*) AS ?totalNumOfRows)
+    WHERE { 
+    ?record ?p <http://d-nb.info/gnd/118529692> ;  #- Hanns Eisler
+            dct:subject ?cosubjectUri .
+          }
+    # Returns => 2279
+
+Using the total count of rows for a certain GND-ID we compute `d` augument the GND-ID graph for `Hanns Eisler` with this information.
+
+    SELECT ?cosubjectUri (COUNT(?record) AS ?recordCount)
+    WHERE { 
+    	 ?record ?p <http://d-nb.info/gnd/118529692> ;
+            dct:subject ?cosubjectUri . #- Hanns Eisler
+          }
+          GROUP By ?cosubjectUri
+          ORDER BY DESC(?recordCount)
+          # returns:  
+          #<http://lod.b3kat.de/ssg/9.2>		595 * 100 / 2279 => 26% 
+          #<http://lod.b3kat.de/rvk/LU91850>	226 * 100 / 2279 => 10%
+          #<http://d-nb.info/gnd/118529692>	165 * 100 / 2279 => 7%
 
 <a name="UseCaseTaskDetails5"></a> 
 ####5: Get texts from other B3Kat documents referencing the concept


### PR DESCRIPTION
pls cf. sect. 5 : I think it is not suited to get coocurrent B3Kat concepts, which are identifiers for the records in B3Kat library catalogue. The goal is to compute the coocurrence of a GND to other GNDs and Subject-Identifiers from other Subject-Vocabularies (RVK, DDC, Lccn). Hence, I propose to compute the coocurrence of concepts directly and attach it to the GND-Graphs from Step 1. This will result in many triples but we may cut of adding coocurrece relation triples to a GND-Graph (Hanns Eisler) at a certain degree of coocurrence, i.e. 5-10%...
