### PR TITLE
Fixed typo and add details to step 7

### DIFF
--- a/d5.4-deliverable-report.md
+++ b/d5.4-deliverable-report.md
@@ -441,9 +441,9 @@ Extracted Named Entities will be represented in the results by using the [Entity
 <a name="UseCaseTaskDetails7"></a> 
 ####7: Match thesauri concepts to each GND
 
-In this step, we will perform *entity linking* against each GND ID with the aim to detect mentions of GND IDs in the titles and sub-titles of the LKC data. Mentioned GND Ids will be represented in the results by using [Entity Annotation](https://github.com/fusepoolP3/overall-architecture/blob/master/wp3/fp-anno-model/fp-anno-model.md#entity-annotation) as defined by the Fusepool Annotation Model (FAM).
+In this step, we will perform *entity linking* against each GND ID with the aim to detect mentions of GND IDs in the titles and sub-titles of the LKC data. If the GND ID has a `owl:sameAs` relation to DBpedia, then we might also consider the `dbpedia-owl:abstract` or `rdfs:comment` property of the linked DBpedia page to find additional concepts that appear in the context of the base GND ID. The Mentioned GND Ids will be represented in the results by using [Entity Annotation](https://github.com/fusepoolP3/overall-architecture/blob/master/wp3/fp-anno-model/fp-anno-model.md#entity-annotation) as defined by the Fusepool Annotation Model (FAM).
 
-NOTE: this is different from the *Named Entity Recognition* in step 6. *NER* detects types of Entities in the text without the need of any controlled vocabulary. This means that NER can detect new/unknown entities. *Entity linking* works based on a controlled vocabulary - in that case the GND. It uses the names (preferred and alternate) as input and looks for mentions of those in the text. If it finds such a mention is links the according entity with that mention in the text.
+NOTE: this is different from the *Named Entity Recognition* in step 6. *NER* detects types of Entities in the text without the need of any controlled vocabulary. This means that NER can detect new/unknown entities. *Entity linking* works based on a controlled vocabulary - in that case the GND. It uses the names (preferred and alternate) as input and looks for mentions of those in the text. If it finds such a mention it links the according entity with that mention in the text.
 
 The Fusepool platform provides several entity linking implementations. Options include:
  


### PR DESCRIPTION
If the GND ID has a `owl:sameAs` relation to DBpedia, then we might also consider the `dbpedia-owl:abstract` or `rdfs:comment` property of the linked DBpedia page to find additional concepts that appear in the context of the base GND ID.
