### PR TITLE
Update d5.4-deliverable-report.md

### DIFF
--- a/d5.4-deliverable-report.md
+++ b/d5.4-deliverable-report.md
@@ -172,30 +172,27 @@ The LKC use case centres on the interlinking of three large RDF datasets:  two l
 
 <a name="DNBDataset"></a> 
 ####DNB Datasets
-The German National Library (DNB) is dedicated to collect and describe all contents published in Germany in order to make cultural heritage accessible in the long term. The [Linked Data Service of the German National Library](http://www.dnb.de/EN/Service/DigitaleDienste/LinkedData/linkeddata_node.html) has made their entire Datasets (i.e. [DNB catalogue](http://datendienst.dnb.de/cgi-bin/mabit.pl?cmd=fetch&userID=opendata&pass=opendata&mabheft=DNBTitel.ttl.gz) and the national [Authority File (GND)](http://datendienst.dnb.de/cgi-bin/mabit.pl?cmd=fetch&userID=opendata&pass=opendata&mabheft=GND.ttl.gz)) available as Linked Data.
+The German National Library (DNB) is dedicated to collecting and describing all content published in Germany in order to make cultural heritage accessible in the long term. The [Linked Data Service of the German National Library](http://www.dnb.de/EN/Service/DigitaleDienste/LinkedData/linkeddata_node.html) has made their entire dataset (i.e. [DNB catalogue](http://datendienst.dnb.de/cgi-bin/mabit.pl?cmd=fetch&userID=opendata&pass=opendata&mabheft=DNBTitel.ttl.gz) and the national [Authority File (GND)](http://datendienst.dnb.de/cgi-bin/mabit.pl?cmd=fetch&userID=opendata&pass=opendata&mabheft=GND.ttl.gz)) available as Linked Data.
 
 ###### Catalogue
-The catalogue contains bibliographic descriptions both for print and electronic materials. The DNB catalogue contains 11.953.014 records as of {TODO: date} and is available free of charge through the [Linked Data Service of the German National Library](http://www.dnb.de/EN/Service/DigitaleDienste/LinkedData/linkeddata_node.html). The Catalogue is roughly {TODO: exact size in GB}.
+The catalogue contains bibliographic descriptions for both print and electronic materials. The DNB catalogue contains 11.953.014 records as of 13th May 2015 and is available free of charge through the [Linked Data Service of the German National Library](http://www.dnb.de/EN/Service/DigitaleDienste/LinkedData/linkeddata_node.html). The catalogue is roughly 1.2 GB.
 
 ###### GND 
-The [Integrated Authority File](http://en.wikipedia.org/wiki/Integrated_Authority_File) (German: Gemeinsame Normdatei) or GND is the national authority file for the unique identification of entities (e.g. personal names, subject headings, corporate bodies, etc.). As a controlled vocabulary it is used for organization of alternative labels for entities, as well as their semantic relations. According to its broad application, the GND is the most important vocabulary to describe publications' contents in Germany and German-speaking countries in Europe. It is mainly used by libraries, but increasingly also by archives and museums. GNDs is hosted by the German National Library (Deutsche National Bibliothek) and maintained in cooperation with various library networks.
+The [Integrated Authority File](http://en.wikipedia.org/wiki/Integrated_Authority_File) (German: Gemeinsame Normdatei) or GND is the national authority file for the unique identification of entities (e.g. personal names, subject headings, corporate bodies, etc.). As a controlled vocabulary, it is used for the organization of alternative labels for entities, as well as their semantic relations. According to its broad application, the GND is the most important vocabulary to describe publications' contents in Germany and German-speaking countries in Europe. It is mainly used by libraries, but increasingly also by archives and museums. GNDs are hosted by the German National Library (Deutsche National Bibliothek) and maintained in cooperation with various library networks.
 According to [LOD Stats](http://stats.lod2.eu/rdfdocs/157), it contains 124.402.922 triples about 36.575.972 entities, organized in 48 classes and 189 properties. It has a size of around 10GB (decompressed). 
 
 <a name="B3KatDataset"></a> 
 ####B3Kat Dataset
-[B3Kat](http://www.b3kat.de/) is the "common union catalogue" of [BVB](http://www.bib-bvb.de/) (Bavarian Library Network) and [KOBV](http://www.kobv.de/) (Cooperative Library Network Berlin-Brandenburg). The [B3Kat Linked Open Data Service](https://lod.b3kat.de/) provides serveral cataloguing services and aggregates library data of 180 academic libraries in Bavaria, Berlin and Brandenburg, describing roughly 26 million titles. 
+[B3Kat](http://www.b3kat.de/) is the "common union catalogue" of [BVB](http://www.bib-bvb.de/) (Bavarian Library Network) and [KOBV](http://www.kobv.de/) (Cooperative Library Network Berlin-Brandenburg). The [B3Kat Linked Open Data Service](https://lod.b3kat.de/) provides several cataloguing services and aggregates library data of 180 academic libraries in Bavaria, Berlin and Brandenburg, describing roughly 26 million titles. 
 
 The [B3Kat RDF data dump](https://lod.b3kat.de/download) contains about 890 million RDF triples in 7.7GB of data.
 
-Data contained in the set is about all publications (Text-Books, Dissertations, Journals, Maps, Audio recordings, etc.) aquired by the 180 member libraries. Opposing to the DNB catalogue (see above), these publications don't have to be published in Germany. Moreover, the dataset contains descriptions about libraries and their locations. A sample record can be seen here: https://lod.b3kat.de/page/title/BV023184541.
-
-{TO DO: Add some more information about the Data structure}.
+Data contained in the dataset is about all publications (textbooks, dissertations, journals, maps, audio recordings, etc.) acquired by the 180 member libraries. In contrast to the DNB catalogue (see above), these publications don't have to be published in Germany. Moreover, the dataset contains descriptions about libraries and their locations. A sample record can be seen here: <https://lod.b3kat.de/page/title/BV023184541>.
 
 <a name="DBpediaDataset"></a> 
 ####DBpedia Dataset
-The [DBpedia](http://dbpedia.org) dataset describes 4.58 million entities, including 1,445,000 persons, 735,000 places, and 241,000 organizations. The dataset features labels and abstracts for these entities in up to 125 different languages; 25.2 million links to images and 29.8 million links to external web pages. It consists of 3 billion RDF triples, out of which 580 million were extracted from the English edition of Wikipedia, 2.46 billion were extracted from other language editions. DBpedia is connected with other Linked Datasets by around 50 million RDF links. [DBpedia dumps](http://wiki.dbpedia.org/Downloads) in 119 languages are available on the DBpedia download server.
+The [DBpedia](http://dbpedia.org) dataset describes 4.58 million entities, including 1,445,000 persons, 735,000 places, and 241,000 organizations. The dataset features labels and abstracts for these entities in up to 125 different languages; 25.2 million links to images and 29.8 million links to external web pages. It consists of 3 billion RDF triples, out of which 580 million were extracted from the English edition of Wikipedia, 2.46 billion were extracted from other language editions. DBpedia is connected with other Linked Datasets by around 50 million RDF links. [DBpedia dumps](http://wiki.dbpedia.org/Downloads) in 119 languages are available on the DBpedia download server. Assuming only the English and German localized datasets are used for LKC, we estimate the DBpedia corpus in this application context will contribute of the order of 1 billion triples.
 
-{TO DO: Are these numbers correct? 3 billion DBpedia alone? There is another number later in this document when we calculate the total amount of triples.}
 
 <a name="InitialDatasetConnections"></a> 
 ### Initial Dataset Connections
@@ -256,10 +253,8 @@ The source datasets total approximately 2 billion triples:
 | Source dataset | Approximate size |
 | :-- | :-- |
 | GND | 124 million triples |
-| B3Cat | 890 million triples |
-| Dbpedia | 1 billion triples (assuming the full dataset and associated ontologies are loaded) |
-
-{TO DO: These numbers do not correspond to the numbers above in the overview. Either we need to say that we use a subset of them or we correct it accordingly.}
+| B3Kat | 890 million triples |
+| Dbpedia | 1 billion triples (assuming only the English and German localized datasets and associated ontologies are loaded) |
 
 We estimate the resultant transformed aggregated data will comprise under 1 billion triples - a Turtle mockup of the desired output by the end users suggests that there will be ~200 triples per subject. Assuming the source data covers approximately 3 million authors, the output data will be of the order of 600 million triples held in LDP storage.
 
@@ -441,28 +436,28 @@ For each RDF document, we use the contained titles of books related to the core 
 
 #####NER for LKC - Implementation
 
-Stanbol supports a number of NLP/NER frameworks including Stanford NLP and OpenNLP. For this use case, OpenNLP will be used as it provides a basic NER model that can detect Persons, Organizations and Locations in German language texts. While there is also a German model for Stanford NLP this is only available for an older software version that is not compatible with the Stanford/Stanbol integration. As their are also English books to be processed OpenNLP will be configured with both German and English language models.
+Stanbol supports a number of NLP/NER frameworks including Stanford NLP and OpenNLP. For this use case, OpenNLP will be used as it provides a basic NER model that can detect persons, organizations and locations in German language texts. While there is also a German model for Stanford NLP, this is only available for an older software version that is not compatible with the Stanford/Stanbol integration. As there are also English books to be processed, OpenNLP will be configured with both German and English language models.
 
 In common with most of the other Stanbol enhancement engines, OpenNLP accepts plain text. The [Literal Extraction Transformer]( https://github.com/fusepoolP3/p3-literal-extraction-transformer) will provide the plain text input to OpenNLP, by combining the Literal Extraction and Stanbol transformers in a pipeline. The Literal Extraction Transformer can be configured to iterate over specific literal predicates in particular languages, concatenating the text for the same language and emitting plain text.
 
 #####NER for LKC - Expectations
 
-Public available NER models typically include support for Persons, Organizations and Places and are trained based on news text corpora. In-domain (meaning when applied to news texts other than the training set) those systems typically reach F1 measures above 90%. However when applied to other type of texts the performance can drop drastically.
+Publicly available NER models typically include support for persons, organizations and places and are trained based on news text corpora. In-domain (meaning when applied to news texts other than the training set) those systems typically reach F1 measures above 90%. However when applied to other types of texts the performance can drop drastically.
 
-Expected input texts for the LKC domain will be very different from news texts. Texts are essentially concatenated titles and sub titles. Meaning that the texts will not contain full sentences nor will sentences be connected to previous sentences.
+Expected input texts for the LKC domain will be very different from news texts. Texts are essentially concatenated titles and sub-titles. Meaning that the texts will not contain full sentences nor will sentences be connected to previous sentences.
 
 Because of that we expect available NER models to perform very badly on the data of this use case. Nevertheless, in spite of reservations about the quality of expected NER results,  we believe the use case is fit for purpose for validating that the platform can handle large amounts of data.
 
-To obtain better results, it would be necessary to train specific NER models based on a training set on the LKC texts. Experience on other datasets suggests that one can train a reasonable good model with about 3000 manually annotated entities per entity type. We consider training an LKC-specific model to be outside the scope of this validation task.
+To obtain better results, it would be necessary to train specific NER models based on a training set on the LKC texts. Experience on other datasets suggests that one can train a reasonably good model with about 3000 manually annotated entities per entity type. We consider training an LKC-specific model to be outside the scope of this validation task.
 
 Extracted Named Entities will be represented in the results by using the [Entity Mention Annotation](https://github.com/fusepoolP3/overall-architecture/blob/master/wp3/fp-anno-model/fp-anno-model.md#entity-mention-annotation) as defined by the Fusepool Annotation Model (FAM). The [Literal Extraction Transformer]( https://github.com/fusepoolP3/p3-literal-extraction-transformer) consumes those annotations and converts them to explicit triples to be added to the enriched LKC dataset.
 
 <a name="UseCaseTaskDetails7"></a> 
 ####7: Match thesauri concepts to each GND
 
-In this step, we will perform *entity linking* against each GND ID with the aim to detect mentions of GND IDs in the titles and sub-titles of the LKC data. If the GND ID has a `owl:sameAs` relation to DBpedia, then we might also consider the `dbpedia-owl:abstract` or `rdfs:comment` property of the linked DBpedia page to find additional concepts that appear in the context of the base GND ID. The Mentioned GND Ids will be represented in the results by using [Entity Annotation](https://github.com/fusepoolP3/overall-architecture/blob/master/wp3/fp-anno-model/fp-anno-model.md#entity-annotation) as defined by the Fusepool Annotation Model (FAM).
+In this step, we will perform *entity linking* against each GND ID with the aim of detecting mentions of GND IDs in the titles and sub-titles of the LKC data. If the GND ID has a `owl:sameAs` relation to DBpedia, then we might also consider the `dbpedia-owl:abstract` or `rdfs:comment` property of the linked DBpedia page to find additional concepts that appear in the context of the base GND ID. The mentioned GND IDs will be represented in the results by using [Entity Annotation](https://github.com/fusepoolP3/overall-architecture/blob/master/wp3/fp-anno-model/fp-anno-model.md#entity-annotation) as defined by the Fusepool Annotation Model (FAM).
 
-NOTE: this is different from the *Named Entity Recognition* in step 6. *NER* detects types of Entities in the text without the need of any controlled vocabulary. This means that NER can detect new/unknown entities. *Entity linking* works based on a controlled vocabulary - in that case the GND. It uses the names (preferred and alternate) as input and looks for mentions of those in the text. If it finds such a mention it links the according entity with that mention in the text.
+NOTE: This is different from the *Named Entity Recognition* in step 6. *NER* detects types of entities in the text without the need of any controlled vocabulary. This means that NER can detect new/unknown entities. *Entity linking* works based on a controlled vocabulary - in that case the GND. It uses the names (preferred and alternate) as input and looks for mentions of those in the text. If it finds such a mention it links the according entity with that mention in the text.
 
 The Fusepool platform provides several entity linking implementations. Options include:
  
@@ -470,9 +465,9 @@ The Fusepool platform provides several entity linking implementations. Options i
  * Stanbol Entityhub Linking Engine
  * Stanbol FST Linking Engine 
 
-For this use case we will use the [FST Linking egine](http://stanbol.apache.org/docs/trunk/components/enhancer/engines/lucenefstlinking) of Apache Stanbol as this one is most efficient for linking against vocabularies with the size of the GND. The index required by the FST Linking Engine will be build in a pre-processing step by using the RDF indexing tool provided by Apache Stanbol.
+For this use case we will use the [FST Linking Engine](http://stanbol.apache.org/docs/trunk/components/enhancer/engines/lucenefstlinking) of Apache Stanbol as this one is most efficient for linking against vocabularies of the size of the GND. The index required by the FST Linking Engine will be built in a pre-processing step by using the RDF indexing tool provided by Apache Stanbol.
 
-As with step 6, the Literal Extraction Transformer will be used to collect and concatenate the input text from literals of processed Entities. The Literal Extraction Transformer will also be used to consume the extraction results represented by the Fusepool Annotation Model (FAM) and convert them to explicit triples to be added to the enriched LKC data.
+As with step 6, the Literal Extraction Transformer will be used to collect and concatenate the input text from literals of processed entities. The Literal Extraction Transformer will also be used to consume the extraction results represented by the Fusepool Annotation Model (FAM) and convert them to explicit triples to be added to the enriched LKC data.
 
 In addition to GND IDs Entity Linking will be also provided for the following three SKOS based thesauri:
 
@@ -480,7 +475,7 @@ In addition to GND IDs Entity Linking will be also provided for the following th
  * The [IPTC](https://iptc.org/) media topics [thesaurus](https://iptc.org/standards/media-topics/), a 1100-term taxonomy with a focus on categorizing text. The Media Topics vocabulary can be viewed on the [IPTC Controlled Vocabulary server]( http://cv.iptc.org/newscodes/mediatopic).
  * The [STW Thesaurus for Economics](http://zbw.eu/stw/versions/latest/download/about.en.html).
 
-The Thesaurus for the Social Sciences (theSoz) is curated by [GESIS](http://www.gesis.org/en/institute/), the largest infrastructure institution for the Social Sciences in Germany (Leibniz Institute for Social Sciences)[1]. GESIS reviews and describes a vast amount of publications from major journals in the Social Sciences, in order to make research retrievable at a central hub. TheSoz is used to describe the contents of scientific efforts with a controlled language (Thesaurus). The list of keywords contains about 12,000 entries, of which more than 8,000 are descriptors (authorised keywords) and about 4,000 non-descriptors (synonyms). All major topics in the social science disciplines are included in three european languages (german, french, english).
+The Thesaurus for the Social Sciences (TheSoz) is curated by [GESIS](http://www.gesis.org/en/institute/), the largest infrastructure institution for the Social Sciences in Germany (Leibniz Institute for Social Sciences)[1]. GESIS reviews and describes a vast amount of publications from major journals in the Social Sciences, in order to make research retrievable at a central hub. TheSoz is used to describe the contents of scientific efforts with a controlled language (thesaurus). The list of keywords contains about 12,000 entries, of which more than 8,000 are descriptors (authorised keywords) and about 4,000 non-descriptors (synonyms). All major topics in the social science disciplines are included in three European languages (German, French, English).
  
 
 <a name="UseCaseTaskDetails8"></a> 
@@ -488,7 +483,7 @@ The Thesaurus for the Social Sciences (theSoz) is curated by [GESIS](http://www.
 
 Some entities are not covered by the GND, or the subject terminologies. In order to find additional related concepts in DBpedia and related Wiki pages in Wikipedia, we propose trying to find them using alternative entity linking services. Two candidate services are [dataTXT](http://dandelion.eu/datatxt/) and [DBpedia Spotlight](https://github.com/dbpedia-spotlight/dbpedia-spotlight/wiki). Both are available as Stanbol enhancement engines, accessible through the FP3 Stanbol Enhancer Transformer.
 
-dataTXT is a named entity extraction & linking service that, given a plain text, gives back a set of entities found in the text and links to corresponding entries in Wikipedia. It also optionally returns the entity type from DBpedia. 
+dataTXT is a named entity extraction and linking service that, given a plain text, gives back a set of entities found in the text and links to corresponding entries in Wikipedia. It also optionally returns the entity type from DBpedia. 
 
 dataTXT performs very well even on short texts, on which many other similar services do not. It is based on co-references of entities, it does not use any NLP feature. Even if the input texts are not complete sentences, we expect it to return valid results. For this reason it is our preferred service for this step.
 
@@ -621,18 +616,18 @@ For the LKC use case the following information extraction workflow is expected
 
 The [Literal Extraction Transformer](https://github.com/fusepoolP3/p3-literal-extraction-transformer) is used to collect literals of the source RDF data to be used for information extraction. It also processes the information extraction results encoded using the [Fusepool Annotation Model](https://github.com/fusepoolP3/overall-architecture/blob/master/wp3/fp-anno-model/fp-anno-model.md) (FAM) and converts them to simple statements for the enriched RDF data.
 
-The Literal Extraction Transformer is configured with a second transformer doing the actual information extraction work. As for the LKC use case Apache Stanbol is used for the information extraction work the [Stanbol Enhancer Transformer](https://github.com/fusepoolP3/p3-stanbol-enhancer-adapter/tree/master/service) is configured. This "transformer adapter" for the Apache Stanbol Enhancer allows to use Stanbol Enhancement Chains or single Enhancement Engines as Fusepool Transformers.
+The Literal Extraction Transformer is configured with a second transformer doing the actual information extraction work. As for the LKC use case Apache Stanbol is used for the information extraction work the [Stanbol Enhancer Transformer](https://github.com/fusepoolP3/p3-stanbol-enhancer-adapter/tree/master/service) is configured. This "transformer adapter" for the Apache Stanbol Enhancer allows the use of Stanbol Enhancement Chains or single Enhancement Engines as Fusepool Transformers.
 
-As the LKC use case requires several information extraction capabilities a Enhancement Chain supporting (1) Named Entity Linking , (2) Entity Linking against the GND, GESIS, STW and IPTC and (3) DBpedia linking by using the DataTXT engine is configured. As Stanbol uses the FISE annotation model also an engine that converts FISE into the Fusepool Annotation Model is required.
+As the LKC use case requires several information extraction capabilities, an Enhancement Chain supporting (1) Named Entity Linking , (2) Entity Linking against the GND, GESIS, STW and IPTC and (3) DBpedia linking by using the DataTXT engine is configured. As Stanbol uses the FISE annotation model, an engine that converts FISE into the Fusepool Annotation Model is also required.
 
-All the transformers and Stanbol components mentioned above are described in detail in D3.1: Section 9 provides details about the Fusepool Annotation Model; Section 10.1 gives details about the integration of Apache Stanbol to the Fusepool Plattform as Transformer. Section 10.2 provides details about the DataTXT integration.
+All the transformers and Stanbol components mentioned above are described in detail in D3.1: Section 9 provides details about the Fusepool Annotation Model; Section 10.1 gives details about the integration of Apache Stanbol into the Fusepool Platform as a transformer. Section 10.2 provides details about the DataTXT integration.
 
-The remainder of this appendix aims to provide a short overview on Apache Stanbol components used for the LKC use case.
+The remainder of this appendix aims to provide a short overview of Apache Stanbol components used for the LKC use case.
 
 <a name="AppendixBEC"></a> 
 ### Enhancement Chain
 
-An [Enhancement Chain](http://stanbol.apache.org/docs/trunk/components/enhancer/chains/) defines how content parsed to the Stanbol Enhancer is processed. More concretely it defines which [Enhancement Engines](http://stanbol.apache.org/docs/trunk/components/enhancer/engines) and in what order are used to process the parsed content. For the LKC use case an Enhancement chain with all the required Information Extraction Capabilities needs to be configured.
+An [Enhancement Chain](http://stanbol.apache.org/docs/trunk/components/enhancer/chains/) defines how content passed to the Stanbol Enhancer is processed. More concretely it defines which [Enhancement Engines](http://stanbol.apache.org/docs/trunk/components/enhancer/engines) are used, and in what order, to process the parsed content. For the LKC use case an Enhancement chain with all the required Information Extraction Capabilities needs to be configured.
 
 A typical Stanbol enhancement workflow is depicted below:
 
@@ -640,7 +635,7 @@ A typical Stanbol enhancement workflow is depicted below:
 
 The typical information extraction workflow used with Apache Stanbol starts with a pre-processing step. In this step the parsed content is prepared for later information extraction. Plain Text extraction from rich text documents is a typical task performed in this step. For the LKC use case this step is not required as this work is already done by the [Literal Extraction Transformer](https://github.com/fusepoolP3/p3-literal-extraction-transformer) outside of Apache Stanbol.
 
-The second step is about natural language processing. For the LKC this includes Language Detection and Named Entity Recognition. As OpenNLP requires Sentence Detection and Tokenization before NER those need also to be configured.
+The second step is about natural language processing. For the LKC, this includes Language Detection and Named Entity Recognition. As OpenNLP requires Sentence Detection and Tokenization before NER, those need also to be configured.
 
 In the Semantic Lifting step the Entity Linking against the four controlled vocabularies and the dataTXT linking to DBPedia will take place.
 
@@ -657,25 +652,25 @@ Apache Stanbol comes with a wide range of Enhancement Engines and users can also
 
 * Language Detection: The most common Language detection engine for Apache Stanbol is the [Langdetect Engine](http://stanbol.apache.org/docs/trunk/components/enhancer/engines/langdetectengine)
 * Named Entity Recognition: For the use case [Apache OpenNLP](http://opennlp.apache.org/) will be used. For Named Entity Recognition the OpenNLP [Sentence Detection](http://stanbol.apache.org/docs/trunk/components/enhancer/engines/opennlpsentence), [Tokenizer](http://stanbol.apache.org/docs/trunk/components/enhancer/engines/opennlptokenizer) and [NER](http://stanbol.apache.org/docs/trunk/components/enhancer/engines/opennlpner) engines will get used.
-* Entity Linking: As the texts for the LKC are not full sentences a linking engine that can link against all words in the text is best suited (PLAIN linking mode). For such a scenario the [FST Linking Engine](http://stanbol.apache.org/docs/trunk/components/enhancer/engines/lucenefstlinking) is best suited. It is based on The Apache Lucene FST (Finit State Transducer) API witch allows it to hold labels of large vocabularies fully in memory (e.g. for all English labels of DBPedia one needs less as 300MByte of memory). 
-* DBPedia Linking: While the FST linking engine could also be used for DBPedia it does not provide support for disambiguation. Because of the we will use the [DataTXT engine](https://github.com/fusepoolP3/p3-datatxt-stanbol) instead. This engine is based on the [DataTXT](https://dandelion.eu/products/datatxt/) service.
+* Entity Linking: As the texts for the LKC are not full sentences a linking engine that can link against all words in the text is best suited (PLAIN linking mode). For such a scenario the [FST Linking Engine](http://stanbol.apache.org/docs/trunk/components/enhancer/engines/lucenefstlinking) is best suited. It is based on The Apache Lucene FST (Finite State Transducer) API witch allows it to hold labels of large vocabularies fully in memory (e.g. for all English labels of DBPedia one needs less as 300MByte of memory). 
+* DBPedia Linking: While the FST linking engine could also be used for DBPedia it does not provide support for disambiguation. Because of this we will use the [DataTXT engine](https://github.com/fusepoolP3/p3-datatxt-stanbol) instead. This engine is based on the [DataTXT](https://dandelion.eu/products/datatxt/) service.
 * Fusepool Annotation Model support: Apache Stanbol uses the [Stanbol Enhancement Structure](http://stanbol.apache.org/docs/trunk/components/enhancer/enhancementstructure). When used as Fusepool Transformer those annotations need to be converted to the Fusepool Annotation Model. The [FAM engine](https://github.com/fusepoolP3/p3-stanbol-engine-fam) implements this conversion.
 
 <a name="AppendixBWCV"></a> 
 ### Working with Custom Vocabularies
 
-For using Entity Linking Engines it is required to create special indexes over custom vocabularies. For small and medium sized vocabularies those can be created while uploading them to Apache Stanbol. Hoever for big vocabularies or if one want to have more control on how those indexes are build Apache Stanbol provides a special batch processing tool for creating those.
+For using Entity Linking Engines it is necessary to create special indexes over custom vocabularies. For small and medium sized vocabularies those can be created while uploading them to Apache Stanbol. However for big vocabularies or if one wants to have more control over how those indexes are built, Apache Stanbol provides a special batch processing tool for creating them.
 
 The whole process is described by the [Working with Custom Vocabularies](https://stanbol.apache.org/docs/trunk/customvocabulary.html) usage scenario.
 
-Here are the main Steps of the process:
+Here are the main steps of the process:
 
 * Build the Entityhub Indexing Tool and grab the binary `org.apache.stanbol.entityhub.indexing.genericrdf-*-jar-with-dependencies.jar`
-* call the binary with the `init` command to initialise the configuration hierarchy
-* edit the `indexing/conig/indexing.properties` file. See comments in this file for more information
-* copy the RDF files of your controlled vocabulary to the `indexing/resources/rdfdata` folder
-* call the binary with the `index` command to index the vocabulary
-* after the indexing finishes the `indexing/dist` folder will contain two files
+* Call the binary with the `init` command to initialise the configuration hierarchy
+* Edit the `indexing/conig/indexing.properties` file. See comments in this file for more information
+* Copy the RDF files of your controlled vocabulary to the `indexing/resources/rdfdata` folder
+* Call the binary with the `index` command to index the vocabulary
+* After the indexing finishes the `indexing/dist` folder will contain two files
     1. `org.apache.stanbol.data.site.{name}-{version}.jar` an OSGI bundle to be installed to the Stanbol runtime. This Bundle provides the Entityhub configuration for the indexed dataset
     2. `{name}.solrindex.zip` an archived Solr core. This needs to be installed as data file to apache stanbol. The easiest way to do this is to copy it to the `stanbol/datafiles` folder of your stanbol instance.
     
@@ -691,7 +686,7 @@ The [Entityhub](https://stanbol.apache.org/docs/trunk/components/entityhub) is t
 * The [IPTC](https://iptc.org/) media topics [thesaurus](https://iptc.org/standards/media-topics/), a 1100-term taxonomy with a focus on categorizing text. The Media Topics vocabulary can be viewed on the [IPTC Controlled Vocabulary server]( http://cv.iptc.org/newscodes/mediatopic).
 * The [STW Thesaurus for Economics](http://zbw.eu/stw/versions/latest/download/about.en.html).
 
-All those indexes will be build using the Entityhub Indexing Tool and afterwards be installed to the Stanbol Runtime.
+All these indexes will be built using the Entityhub Indexing Tool and afterwards be installed in the Stanbol Runtime.
 
 <a name="AppendixC"></a> 
 ## Appendix C: Dataset Sources
@@ -752,7 +747,7 @@ This appendix lists the used data sources which are used for Large Scale validat
 * [Entry page](http://www.gesis.org/en/services/research/thesauri-und-klassifikationen/social-science-thesaurus/)
 * [Direct download](http://www.etracker.de/lnkcnt.php?et=qPKGYV&url=http://www.gesis.org/fileadmin/upload/dienstleistung/tools_standards/thesoz_skos_turtle.zip&lnkname=fileadmin/upload/dienstleistung/tools_standards/thesoz_skos_turtle.zip)
 
-The Turtle file in this thesaurus is not correct Turtle and parsers might fail on it. We load a cleaned Turtle file.
+The Turtle file in this thesaurus is not syntactically correct Turtle and parsers might consequently fail on it. We will load a cleaned Turtle file.
 
 <a name="AppendixCIPTC"></a> 
 ### IPTC


### PR DESCRIPTION
Corrections to inconsistencies in the estimated number of triples contributed by DBpedia to the total LKC data corpus size.
Assorted typo fixes.
